### PR TITLE
fix/game state structure

### DIFF
--- a/Assets/AvoidGame/Prefabs/Play/Manager.prefab
+++ b/Assets/AvoidGame/Prefabs/Play/Manager.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1920646689330154793}
   - component: {fileID: 132172624626960353}
+  - component: {fileID: 6879209010887958034}
   m_Layer: 0
   m_Name: Manager
   m_TagString: Untagged
@@ -47,3 +48,15 @@ MonoBehaviour:
   waitForCountdown: 0
   countdown: 3
   waitAfterFinished: 1
+--- !u!114 &6879209010887958034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6469428081816126800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0d00a0ee1c78bd4c84840a5dfa9794b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/AvoidGame/Prefabs/Statics/Manager.prefab
+++ b/Assets/AvoidGame/Prefabs/Statics/Manager.prefab
@@ -9,7 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5547354874851552301}
-  - component: {fileID: 4612150222068069339}
   m_Layer: 0
   m_Name: Manager
   m_TagString: Untagged
@@ -32,15 +31,3 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4612150222068069339
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7055005527421961966}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a0d00a0ee1c78bd4c84840a5dfa9794b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/AvoidGame/Scenes/Play.unity
+++ b/Assets/AvoidGame/Scenes/Play.unity
@@ -140,6 +140,7 @@ GameObject:
   - component: {fileID: 1712428937}
   - component: {fileID: 1712428936}
   - component: {fileID: 1712428938}
+  - component: {fileID: 1712428939}
   m_Layer: 0
   m_Name: SceneContext
   m_TagString: Untagged
@@ -162,6 +163,7 @@ MonoBehaviour:
   _scriptableObjectInstallers: []
   _monoInstallers:
   - {fileID: 1712428938}
+  - {fileID: 1712428939}
   _installerPrefabs: []
   _findSiblingMonoInstallers: 0
   _autoRun: 1
@@ -208,7 +210,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playSceneManager: {fileID: 6499688800424306456}
-  speedManager: {fileID: 6499688800424306455}
+--- !u!114 &1712428939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712428935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f6b31d61f7f4c7f8270a042b711a64b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeManager: {fileID: 6499688800424306455}
 --- !u!114 &1766781319 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2831719794352795914, guid: 2e4ab6b90a180da4e835a211fb3ba349,
@@ -555,14 +569,14 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 57cfed05e0713fa4ca969dcc778eabcc, type: 3}
 --- !u!114 &6499688800424306455 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4584013991667155891, guid: 57cfed05e0713fa4ca969dcc778eabcc,
+  m_CorrespondingSourceObject: {fileID: 6879209010887958034, guid: 57cfed05e0713fa4ca969dcc778eabcc,
     type: 3}
   m_PrefabInstance: {fileID: 6499688800424306454}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3bfb8071cf712924cb5082b404fafd8e, type: 3}
+  m_Script: {fileID: 11500000, guid: a0d00a0ee1c78bd4c84840a5dfa9794b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &6499688800424306456 stripped

--- a/Assets/AvoidGame/Scripts/Calibration/CalibrationStateManager.cs
+++ b/Assets/AvoidGame/Scripts/Calibration/CalibrationStateManager.cs
@@ -60,7 +60,7 @@ namespace AvoidGame.Calibration
             State = CalibrationState.Finished;
 
             await UniTask.Delay(TimeSpan.FromSeconds(5), cancellationToken: _cts.Token);
-            _gameStateManager.GameState = GameState.CountDown;
+            _gameStateManager.GameState = GameState.Play;
         }
 
         public void Dispose()

--- a/Assets/AvoidGame/Scripts/Calibration/Input/CalibrationInputManager.cs
+++ b/Assets/AvoidGame/Scripts/Calibration/Input/CalibrationInputManager.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.InputSystem;
 using Zenject;
 
 namespace AvoidGame.Calibration.Input
@@ -17,7 +16,7 @@ namespace AvoidGame.Calibration.Input
 
         private void Start()
         {
-            _inputActions.UI.Submit.started += (ctx) => { _gameStateManager.GameState = GameState.CountDown; };
+            _inputActions.UI.Submit.started += (_) => { _gameStateManager.GameState = GameState.Play; };
         }
 
         private void OnDestroy()

--- a/Assets/AvoidGame/Scripts/DI/ManagerInstaller.cs
+++ b/Assets/AvoidGame/Scripts/DI/ManagerInstaller.cs
@@ -9,17 +9,11 @@ namespace AvoidGame.DI
 {
     public class ManagerInstaller : MonoInstaller
     {
-        [SerializeField] private TimeManager _timeManager;
-
         public override void InstallBindings()
         {
             Container.Bind(typeof(GameStateManager), typeof(IInitializable), typeof(IDisposable))
                 .To<GameStateManager>()
                 .FromNew()
-                .AsSingle();
-
-            Container.Bind<TimeManager>()
-                .FromInstance(_timeManager)
                 .AsSingle();
         }
     }

--- a/Assets/AvoidGame/Scripts/GameState.cs
+++ b/Assets/AvoidGame/Scripts/GameState.cs
@@ -1,15 +1,13 @@
-/// <summary>
-/// ゲームの状態
-/// </summary>
 namespace AvoidGame
 {
+    /// <summary>
+    /// ゲームの状態
+    /// </summary>
     public enum GameState
     {
         Title,
         Calibration,
-        CountDown,
-        Playing,
-        Finished,
+        Play,
         Result,
     }
 }

--- a/Assets/AvoidGame/Scripts/Play/DI/PlaySceneManagerInstaller.cs
+++ b/Assets/AvoidGame/Scripts/Play/DI/PlaySceneManagerInstaller.cs
@@ -1,9 +1,8 @@
-using AvoidGame.Play;
 using System;
 using UnityEngine;
 using Zenject;
 
-namespace AvoidGame.DI
+namespace AvoidGame.Play.DI
 {
     public class PlaySceneManagerInstaller : MonoInstaller
     {

--- a/Assets/AvoidGame/Scripts/Play/DI/TimeManagerInstaller.cs
+++ b/Assets/AvoidGame/Scripts/Play/DI/TimeManagerInstaller.cs
@@ -1,0 +1,16 @@
+using System;
+using UnityEngine;
+using Zenject;
+
+namespace AvoidGame.Play.DI
+{
+    public class TimeManagerInstaller : MonoInstaller<TimeManagerInstaller>
+    {
+        [SerializeField] private TimeManager timeManager;
+
+        public override void InstallBindings()
+        {
+            Container.BindInstance(timeManager).AsSingle();
+        }
+    }
+}

--- a/Assets/AvoidGame/Scripts/Play/DI/TimeManagerInstaller.cs.meta
+++ b/Assets/AvoidGame/Scripts/Play/DI/TimeManagerInstaller.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0f6b31d61f7f4c7f8270a042b711a64b
+timeCreated: 1699190201

--- a/Assets/AvoidGame/Scripts/Play/Interface/IPlaySceneManager.cs
+++ b/Assets/AvoidGame/Scripts/Play/Interface/IPlaySceneManager.cs
@@ -1,3 +1,7 @@
-public interface IPlaySceneManager
+namespace AvoidGame.Play.Interface
 {
+    public interface IPlaySceneManager
+    {
+        public PlaySceneState State { get; }
+    }
 }

--- a/Assets/AvoidGame/Scripts/Play/Items/ItemBase.cs
+++ b/Assets/AvoidGame/Scripts/Play/Items/ItemBase.cs
@@ -10,18 +10,18 @@ namespace AvoidGame.Play.Items
     public abstract class ItemBase : MonoBehaviour
     {
         public virtual bool DestroyOnItemCollectorHit => true;
-    
+
         public event Action<Collider> OnItemCollectorHit;
-    
-        [Inject] private GameStateManager gameStateManager;
+
+        [Inject] private PlaySceneManager _playSceneManager;
 
         private void OnTriggerEnter(Collider other)
         {
-            if (gameStateManager.GameState != GameState.Playing) return;
+            if (_playSceneManager.State != PlaySceneState.Playing) return;
             if (!other.TryGetComponent(out IItemCollectable _)) return;
-        
+
             OnItemCollectorHit?.Invoke(other);
-        
+
             if (DestroyOnItemCollectorHit)
             {
                 Destroy(gameObject);

--- a/Assets/AvoidGame/Scripts/Play/PlaySceneManager.cs
+++ b/Assets/AvoidGame/Scripts/Play/PlaySceneManager.cs
@@ -1,20 +1,21 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
+using AvoidGame.Play.Interface;
 using UnityEngine;
 using Zenject;
 
-/// <summary>
-/// Playシーンを管理する
-/// </summary>
 namespace AvoidGame.Play
 {
+    /// <summary>
+    /// Playシーンを管理する
+    /// </summary>
     public class PlaySceneManager : MonoBehaviour, IPlaySceneManager
     {
         /// <summary>
         /// カウントダウン時のイベント
         /// </summary>
         public event Action OnCountStart;
+
         public event Action<int> OnCountChanged;
 
         [SerializeField] private float waitForCountdown = 0f;
@@ -22,6 +23,20 @@ namespace AvoidGame.Play
         [SerializeField] private float waitAfterFinished = 0f;
 
         [Inject] private GameStateManager _gameStateManager;
+
+        private PlaySceneState _sceneState = PlaySceneState.Countdown;
+
+        public event Action<PlaySceneState> OnPlayStateChanged;
+
+        public PlaySceneState State
+        {
+            get => _sceneState;
+            private set
+            {
+                OnPlayStateChanged?.Invoke(value);
+                _sceneState = value;
+            }
+        }
 
         void Start()
         {
@@ -44,7 +59,8 @@ namespace AvoidGame.Play
                 yield return new WaitForSeconds(1);
                 count--;
             }
-            _gameStateManager.GameState = GameState.Playing;
+
+            State = PlaySceneState.Playing;
         }
 
         /// <summary>
@@ -53,7 +69,7 @@ namespace AvoidGame.Play
         /// </summary>
         public void Finished()
         {
-            _gameStateManager.GameState = GameState.Finished;
+            State = PlaySceneState.Finished;
             StartCoroutine(TransitToResult());
         }
 

--- a/Assets/AvoidGame/Scripts/Play/PlaySceneState.cs
+++ b/Assets/AvoidGame/Scripts/Play/PlaySceneState.cs
@@ -1,0 +1,9 @@
+namespace AvoidGame.Play
+{
+    public enum PlaySceneState
+    {
+        Countdown,
+        Playing,
+        Finished,
+    }
+}

--- a/Assets/AvoidGame/Scripts/Play/PlaySceneState.cs.meta
+++ b/Assets/AvoidGame/Scripts/Play/PlaySceneState.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4a4cbfc8f7164bf796b2745fe3791566
+timeCreated: 1699187882

--- a/Assets/AvoidGame/Scripts/Play/Players/Player.cs
+++ b/Assets/AvoidGame/Scripts/Play/Players/Player.cs
@@ -1,7 +1,8 @@
+using AvoidGame.Play.Player;
 using UnityEngine;
 using Zenject;
 
-namespace AvoidGame.Play.Player
+namespace AvoidGame.Play.Players
 {
     /// <summary>
     /// プレイヤー
@@ -31,15 +32,15 @@ namespace AvoidGame.Play.Player
         /// </summary>
         private void Update()
         {
-            if(cart.m_Position == path.PathLength && _gameStateManager.GameState == GameState.Playing)
+            if (cart.m_Position == path.PathLength && _playSceneManager.State == PlaySceneState.Playing)
             {
-                _playSceneManager.Finished();   
+                _playSceneManager.Finished();
             }
         }
 
         private void StartRace(GameState gameState)
         {
-            if(gameState == GameState.Playing)
+            if (_playSceneManager.State == PlaySceneState.Playing)
             {
                 cart.m_Speed = default_speed;
             }

--- a/Assets/AvoidGame/Scripts/Play/SpeedManager.cs
+++ b/Assets/AvoidGame/Scripts/Play/SpeedManager.cs
@@ -14,19 +14,21 @@ namespace AvoidGame.Play
     {
         public event Action<float> OnSpeedMultiplierChanged;
         public event Action<float> OnSpeedChanged;
+
         [Inject] GameStateManager _gameStateManager;
+        [Inject] PlaySceneManager _playSceneManager;
 
         /// <summary>
         /// スピード倍率
         /// </summary>
-        public float Speed 
+        private float Speed
         {
             get => _speed;
-            set 
+            set
             {
                 _speed = value;
                 OnSpeedMultiplierChanged?.Invoke(_speed);
-                OnSpeedChanged?.Invoke(_speed*PlayerConstants.default_player_speed);
+                OnSpeedChanged?.Invoke(_speed * PlayerConstants.default_player_speed);
             }
         }
 
@@ -35,7 +37,7 @@ namespace AvoidGame.Play
         public void Initialize()
         {
             Speed = 0f;
-            _gameStateManager.OnGameStateChanged += PlayStart;
+            _playSceneManager.OnPlayStateChanged += PlayStart;
         }
 
         /// <summary>
@@ -53,9 +55,10 @@ namespace AvoidGame.Play
         /// 開始時に倍率を1.0に
         /// </summary>
         /// <param name="gameState"></param>
-        private void PlayStart(GameState gameState)
+        /// <param name="sceneState"></param>
+        private void PlayStart(PlaySceneState sceneState)
         {
-            if(gameState == GameState.Playing)
+            if (sceneState == PlaySceneState.Playing)
             {
                 Speed = 1f;
             }
@@ -63,7 +66,7 @@ namespace AvoidGame.Play
 
         public void Dispose()
         {
-            _gameStateManager.OnGameStateChanged -= PlayStart;
+            _playSceneManager.OnPlayStateChanged -= PlayStart;
         }
     }
 }

--- a/Assets/AvoidGame/Scripts/Play/Tests/UIs/Panels/Impl/CountDownPanel.cs
+++ b/Assets/AvoidGame/Scripts/Play/Tests/UIs/Panels/Impl/CountDownPanel.cs
@@ -1,11 +1,7 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-namespace AvoidGame.Play.Test.UI
+namespace AvoidGame.Play.Tests.UIs.Panels.Impl
 {
     public class CountDownPanel : PanelBase
     {
-        public override GameState TargetState => GameState.CountDown;
+        public override PlaySceneState TargetState => PlaySceneState.Countdown;
     }
 }

--- a/Assets/AvoidGame/Scripts/Play/Tests/UIs/Panels/Impl/PlayingPanel.cs
+++ b/Assets/AvoidGame/Scripts/Play/Tests/UIs/Panels/Impl/PlayingPanel.cs
@@ -1,11 +1,9 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using AvoidGame.Play.Test.UI;
 
-namespace AvoidGame.Play.Test.UI
+namespace AvoidGame.Play.Tests.UIs.Panels.Impl
 {
     public class PlayingPanel : PanelBase
     {
-        public override GameState TargetState => GameState.Playing;
+        public override PlaySceneState TargetState => PlaySceneState.Playing;
     }
 }

--- a/Assets/AvoidGame/Scripts/Play/Tests/UIs/Panels/PanelBase.cs
+++ b/Assets/AvoidGame/Scripts/Play/Tests/UIs/Panels/PanelBase.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Zenject;
 
-namespace AvoidGame.Play.Test.UI
+namespace AvoidGame.Play.Tests.UIs.Panels
 {
     /// <summary>
     /// パネルの基底クラス
@@ -10,23 +10,23 @@ namespace AvoidGame.Play.Test.UI
     /// </summary>
     public abstract class PanelBase : MonoBehaviour
     {
-        public virtual GameState TargetState { get; }
-    
-        [Inject] private GameStateManager _gameStateManager;
-    
+        public virtual PlaySceneState TargetState { get; }
+
+        [Inject] private PlaySceneManager _playSceneManager;
+
         private void Awake()
         {
-            _gameStateManager.OnGameStateChanged += ChangePanelActivation;
+            _playSceneManager.OnPlayStateChanged += ChangePanelActivation;
         }
 
-        private void ChangePanelActivation(GameState gameState)
+        private void ChangePanelActivation(PlaySceneState state)
         {
-            gameObject.SetActive(gameState == TargetState);
+            gameObject.SetActive(state == TargetState);
         }
 
         private void OnDisable()
         {
-            _gameStateManager.OnGameStateChanged -= ChangePanelActivation;
+            _playSceneManager.OnPlayStateChanged -= ChangePanelActivation;
         }
     }
 }

--- a/Assets/AvoidGame/Scripts/SceneTransitionManager.cs
+++ b/Assets/AvoidGame/Scripts/SceneTransitionManager.cs
@@ -64,17 +64,7 @@ namespace AvoidGame
         /// <param name="gameState"></param>
         public void OnGameStateChanged(GameState gameState)
         {
-            Debug.Log($"OnGameStateChanged: {gameState}");
-            foreach (SceneTransitionStructure s in scenes)
-            {
-                if (s.targetState == gameState)
-                {
-                    // fire and forget
-                    LoadSceneAsync(s.sceneName.ToString(), this.GetCancellationTokenOnDestroy()).Forget();
-                    Debug.Log($"LoadSceneAsync: {s.sceneName}");
-                    break;
-                }
-            }
+            LoadSceneAsync(gameState.ToString(), this.GetCancellationTokenOnDestroy()).Forget();
         }
 
         /// <summary>

--- a/Assets/AvoidGame/Scripts/Tester/TestSceneTransitionManager.cs
+++ b/Assets/AvoidGame/Scripts/Tester/TestSceneTransitionManager.cs
@@ -76,7 +76,7 @@ namespace AvoidGame.Tester
                 {
                     if (s.sceneName == SceneName.Calibration && skipCalibration)
                     {
-                        _gameStateManager.LockGameState(GameState.CountDown);
+                        _gameStateManager.LockGameState(GameState.Play);
                         return;
                     }
 

--- a/Assets/AvoidGame/Scripts/TimeManager.cs
+++ b/Assets/AvoidGame/Scripts/TimeManager.cs
@@ -1,18 +1,18 @@
 using System;
-using System.Collections;
+using AvoidGame.Play;
 using UnityEngine;
-using UnityEngine.Jobs;
-using UnityEngine.SceneManagement;
 using Zenject;
 using AvoidGame.TimeRecorder;
 
-/// <summary>
-/// ゲームの時間を管理する
-/// </summary>
 namespace AvoidGame
 {
+    /// <summary>
+    /// ゲームの時間を管理する
+    /// </summary>
     public class TimeManager : MonoBehaviour
     {
+        [Inject] PlaySceneManager _playSceneManager;
+
         private bool counting = false;
 
         private long start_time;
@@ -31,29 +31,28 @@ namespace AvoidGame
 
         private long _mainTimer;
 
-        [Inject] private GameStateManager _gameStateManager;
         [Inject] private ITimeRecordable _timeRecordable;
 
-        public void Start()
+        public void Awake()
         {
-            _gameStateManager.OnGameStateChanged += ChangeTimerCondition;
+            _playSceneManager.OnPlayStateChanged += ChangeTimerCondition;
         }
 
-        private void ChangeTimerCondition(GameState gameState)
+        private void ChangeTimerCondition(PlaySceneState state)
         {
-            switch (gameState)
+            switch (state)
             {
-                case GameState.Title:
+                case PlaySceneState.Countdown:
                     ResetParams();
                     break;
-                case GameState.Playing:
+                case PlaySceneState.Playing:
                     StartCount();
                     break;
-                case GameState.Finished:
-                    StopCount(); 
+                case PlaySceneState.Finished:
+                    StopCount();
                     break;
                 default:
-                    break;
+                    throw new ArgumentOutOfRangeException(nameof(state), state, null);
             }
         }
 
@@ -67,11 +66,12 @@ namespace AvoidGame
 
         public void StartCount()
         {
-            if(counting) return; 
+            if (counting) return;
             MainTimer = 0;
             start_time = DateTime.Now.Ticks;
             counting = true;
         }
+
         public void StopCount()
         {
             counting = false;
@@ -80,7 +80,7 @@ namespace AvoidGame
 
         private void ResetParams()
         {
-            counting = false ;
+            counting = false;
             MainTimer = 0;
         }
     }


### PR DESCRIPTION
- SceneTransitionManagerとTestSceneTransitionManagerの修正
- カスタムInputActions作成
- InputActionsをDIコンテナに登録する
- シーンのロードとアクティブ化のタイミングを変更 & UniTask化
- inputactionsのキー変更
- canvas変数名変更
- cancellation token source追加
- テスターは完璧に動く
- inputactionsをDIから外す
- GameStateManagerをIDisposableにした
- CancellationTokenの渡し方を修正
- GameStateとPlaySceneStateを切り分け
